### PR TITLE
multi-scheduler's change from 1.6

### DIFF
--- a/deployments/nginx.yaml
+++ b/deployments/nginx.yaml
@@ -8,12 +8,11 @@ spec:
   replicas: 1
   template:
     metadata:
-      annotations:
-        "scheduler.alpha.kubernetes.io/name": hightower
       labels:
         app: nginx
       name: nginx
     spec:
+      schedulerName: hightower
       containers:
         - name: nginx
           image: "nginx:1.11.1-alpine"


### PR DESCRIPTION
"The name of the scheduler responsible for scheduling a pod will be specified using the SchedulerName field of PodSpec instead of using the scheduler.alpha.kubernetes.io/name annotation on Pod."
https://groups.google.com/forum/#!msg/kubernetes-dev/-fwfHQtm9GE/H1TU4yqiBAAJ